### PR TITLE
bug(ES-831975): Folder text is added while rename any of the folders in amazon provider samples of file manager component

### DIFF
--- a/Models/AmazonS3FileProvider.cs
+++ b/Models/AmazonS3FileProvider.cs
@@ -604,7 +604,7 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
             FileManagerDirectoryContent cwd = new FileManagerDirectoryContent();
             AccessPermission PathPermission = GetPathPermission(data[0].FilterPath + data[0].Name, data[0].IsFile);
             List<FileManagerDirectoryContent> files = new List<FileManagerDirectoryContent>();
-            if (!showFileExtension && data[0].IsFile)
+            if (!showFileExtension)
             {
                 newName = newName + data[0].Type;
             }

--- a/Models/AmazonS3FileProvider.cs
+++ b/Models/AmazonS3FileProvider.cs
@@ -604,7 +604,7 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
             FileManagerDirectoryContent cwd = new FileManagerDirectoryContent();
             AccessPermission PathPermission = GetPathPermission(data[0].FilterPath + data[0].Name, data[0].IsFile);
             List<FileManagerDirectoryContent> files = new List<FileManagerDirectoryContent>();
-            if (!showFileExtension)
+            if (!showFileExtension && data[0].IsFile)
             {
                 newName = newName + data[0].Type;
             }


### PR DESCRIPTION
Resolved the issue by including additional conditions to check the **IsFile** value in the response data and updated the new name.