### PR TITLE
912775: Provided Chunk upload support for File Manager component.

### DIFF
--- a/Controllers/AmazonS3ProviderController.cs
+++ b/Controllers/AmazonS3ProviderController.cs
@@ -101,6 +101,7 @@ namespace EJ2AmazonS3ASPCoreFileProvider.Controllers
                     }
                 }
             }
+            operation.HttpContext = HttpContext;
             uploadResponse = operation.Upload(path, uploadFiles, action, dataObject);
             if (uploadResponse.Error != null)
             {

--- a/Controllers/AmazonS3ProviderController.cs
+++ b/Controllers/AmazonS3ProviderController.cs
@@ -101,8 +101,9 @@ namespace EJ2AmazonS3ASPCoreFileProvider.Controllers
                     }
                 }
             }
-            operation.HttpContext = HttpContext;
-            uploadResponse = operation.Upload(path, uploadFiles, action, dataObject);
+            int chunkIndex = Convert.ToInt32(HttpContext.Request.Form["chunk-index"]);
+            int totalChunk = Convert.ToInt32(HttpContext.Request.Form["total-chunk"]);
+            uploadResponse = operation.Upload(path, uploadFiles, action, chunkIndex, totalChunk, dataObject);
             if (uploadResponse.Error != null)
             {
                 Response.Clear();

--- a/Models/AmazonS3FileProvider.cs
+++ b/Models/AmazonS3FileProvider.cs
@@ -15,7 +15,7 @@ using System.Text.Json;
 
 namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
 {
-    public class AmazonS3FileProvider : IAmazonS3FileProviderBase
+    public class AmazonS3FileProvider
     {
         protected static string bucketName;
         static IAmazonS3 client;


### PR DESCRIPTION
**Description:**
Need to handle chunk upload in amazon service provider.
**Solution:**
1. Handled chunk and default upload in amazon service provider. To achieve chunk upload uses the **CompleteMultipartUploadAsync**, **UploadPartAsync** and **InitiateMultipartUploadAsync** methods from the amazon. 
2. Use for partETags: Each part uploaded to S3 gets an ETag. The partETags list keeps track of these ETags along with their corresponding part numbers. When all parts have been uploaded, the CompleteMultipartUploadRequest requires the list of part numbers and their ETags to assemble the final object correctly.
3. **Note:** While working with chunk in amazon cloud, each part must be at least 5 MB in size: https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html