### PR TITLE
1006275: Resolved the upload issue in File Manager component with Amazon service.

### DIFF
--- a/Models/AmazonS3FileProvider.cs
+++ b/Models/AmazonS3FileProvider.cs
@@ -684,7 +684,7 @@ namespace Syncfusion.EJ2.FileManager.AmazonS3FileProvider
                     fullName = fullName.Replace("../", "");
                     if (uploadFiles != null)
                     {
-                        bool isValidChunkUpload = file.ContentType == "application/octet-stream";
+                        bool isValidChunkUpload = file.ContentType == "application/octet-stream" && totalChunk > 0;
                         if (action == "save")
                         {
                             bool isExist = checkFileExist(path, name);


### PR DESCRIPTION
**Description:**
- Files without extensions were sent with Content-Type "application/octet-stream" and were treated as chunked uploads.

**solution:**
- Added a guard so the block-chunk staging/commit logic runs only when chunk metadata is present (i.e., when the upload indicates multiple/any chunks). Otherwise, the method uses the single-shot upload path.